### PR TITLE
Add Spring Boot bills reminder backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# Maven
+/target/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# bills-reminder
+# Bills Reminder
+
+This is a simple Spring Boot backend for registering monthly bills and sending email reminders on their due dates.
+
+## Running
+
+```
+mvn spring-boot:run
+```
+
+## Testing
+
+```
+mvn test
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>com.example</groupId>
+    <artifactId>bills-reminder</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>bills-reminder</name>
+    <description>Spring Boot Bills Reminder Application</description>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/bills/BillsReminderApplication.java
+++ b/src/main/java/com/example/bills/BillsReminderApplication.java
@@ -1,0 +1,14 @@
+package com.example.bills;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication
+@EnableScheduling
+public class BillsReminderApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(BillsReminderApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/bills/controller/BillController.java
+++ b/src/main/java/com/example/bills/controller/BillController.java
@@ -1,0 +1,30 @@
+package com.example.bills.controller;
+
+import com.example.bills.model.Bill;
+import com.example.bills.service.BillService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/bills")
+public class BillController {
+
+    private final BillService billService;
+
+    public BillController(BillService billService) {
+        this.billService = billService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Bill create(@RequestBody Bill bill) {
+        return billService.save(bill);
+    }
+
+    @GetMapping
+    public List<Bill> all() {
+        return billService.findAll();
+    }
+}

--- a/src/main/java/com/example/bills/model/Bill.java
+++ b/src/main/java/com/example/bills/model/Bill.java
@@ -1,0 +1,51 @@
+package com.example.bills.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+import java.time.LocalDate;
+
+@Entity
+public class Bill {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private LocalDate dueDate;
+    private String email;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public LocalDate getDueDate() {
+        return dueDate;
+    }
+
+    public void setDueDate(LocalDate dueDate) {
+        this.dueDate = dueDate;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/com/example/bills/repository/BillRepository.java
+++ b/src/main/java/com/example/bills/repository/BillRepository.java
@@ -1,0 +1,11 @@
+package com.example.bills.repository;
+
+import com.example.bills.model.Bill;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface BillRepository extends JpaRepository<Bill, Long> {
+    List<Bill> findByDueDate(LocalDate dueDate);
+}

--- a/src/main/java/com/example/bills/service/BillService.java
+++ b/src/main/java/com/example/bills/service/BillService.java
@@ -1,0 +1,45 @@
+package com.example.bills.service;
+
+import com.example.bills.model.Bill;
+import com.example.bills.repository.BillRepository;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+public class BillService {
+
+    private final BillRepository billRepository;
+    private final JavaMailSender mailSender;
+
+    public BillService(BillRepository billRepository, JavaMailSender mailSender) {
+        this.billRepository = billRepository;
+        this.mailSender = mailSender;
+    }
+
+    @Transactional
+    public Bill save(Bill bill) {
+        return billRepository.save(bill);
+    }
+
+    public List<Bill> findAll() {
+        return billRepository.findAll();
+    }
+
+    @Scheduled(cron = "0 0 9 * * ?")
+    public void sendDueBillsReminders() {
+        List<Bill> dueBills = billRepository.findByDueDate(LocalDate.now());
+        for (Bill bill : dueBills) {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(bill.getEmail());
+            message.setSubject("Bill due: " + bill.getName());
+            message.setText("Your bill " + bill.getName() + " is due today.");
+            mailSender.send(message);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+spring.datasource.url=jdbc:h2:mem:billsdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.jpa.hibernate.ddl-auto=update
+spring.h2.console.enabled=true
+
+# dummy mail configuration
+spring.mail.host=localhost

--- a/src/test/java/com/example/bills/BillServiceTests.java
+++ b/src/test/java/com/example/bills/BillServiceTests.java
@@ -1,0 +1,39 @@
+package com.example.bills;
+
+import com.example.bills.model.Bill;
+import com.example.bills.repository.BillRepository;
+import com.example.bills.service.BillService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import java.time.LocalDate;
+
+@SpringBootTest
+class BillServiceTests {
+
+    @Autowired
+    private BillService billService;
+
+    @Autowired
+    private BillRepository billRepository;
+
+    @MockBean
+    private JavaMailSender mailSender;
+
+    @Test
+    void sendsReminderForDueBills() {
+        Bill bill = new Bill();
+        bill.setName("Internet");
+        bill.setDueDate(LocalDate.now());
+        bill.setEmail("test@example.com");
+        billRepository.save(bill);
+
+        billService.sendDueBillsReminders();
+
+        Mockito.verify(mailSender).send(Mockito.any());
+    }
+}


### PR DESCRIPTION
## Summary
- initialize Spring Boot project for tracking bills
- send email reminders on bill due dates via scheduled task
- provide REST endpoints and H2-based persistence

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6897599f8ab4832e8997772c32196240