### PR TITLE
Enable live reload with Spring Boot DevTools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,12 @@
             <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>runtime</scope>


### PR DESCRIPTION
## Summary
- add spring-boot-devtools dependency for automatic reloads during development

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689768385a54832e9048eeb55318d06e