### PR TITLE
Fix mock verification for JavaMailSender send overload

### DIFF
--- a/src/test/java/com/example/bills/BillServiceTests.java
+++ b/src/test/java/com/example/bills/BillServiceTests.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.SimpleMailMessage;
 
 import java.time.LocalDate;
 
@@ -34,6 +35,6 @@ class BillServiceTests {
 
         billService.sendDueBillsReminders();
 
-        Mockito.verify(mailSender).send(Mockito.any());
+        Mockito.verify(mailSender).send(Mockito.any(SimpleMailMessage.class));
     }
 }


### PR DESCRIPTION
## Summary
- Fix ambiguous verification in `BillServiceTests` by specifying `SimpleMailMessage`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68976ad5e79c832ea0bea521e7669b4a