### PR TITLE
Add bill type enums with credit card validation

### DIFF
--- a/src/main/java/com/example/bills/model/Bill.java
+++ b/src/main/java/com/example/bills/model/Bill.java
@@ -1,6 +1,8 @@
 package com.example.bills.model;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -16,6 +18,10 @@ public class Bill {
     private String name;
     private LocalDate dueDate;
     private String email;
+    @Enumerated(EnumType.STRING)
+    private BillType type;
+    @Enumerated(EnumType.STRING)
+    private CreditCardName creditCardName;
 
     public Long getId() {
         return id;
@@ -47,5 +53,21 @@ public class Bill {
 
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    public BillType getType() {
+        return type;
+    }
+
+    public void setType(BillType type) {
+        this.type = type;
+    }
+
+    public CreditCardName getCreditCardName() {
+        return creditCardName;
+    }
+
+    public void setCreditCardName(CreditCardName creditCardName) {
+        this.creditCardName = creditCardName;
     }
 }

--- a/src/main/java/com/example/bills/model/BillType.java
+++ b/src/main/java/com/example/bills/model/BillType.java
@@ -1,0 +1,11 @@
+package com.example.bills.model;
+
+public enum BillType {
+    INTERNET,
+    WATER,
+    CELLPHONE_PLAN,
+    MEI,
+    ELECTRICITY,
+    GAS,
+    CREDIT_CARD
+}

--- a/src/main/java/com/example/bills/model/CreditCardName.java
+++ b/src/main/java/com/example/bills/model/CreditCardName.java
@@ -1,0 +1,8 @@
+package com.example.bills.model;
+
+public enum CreditCardName {
+    INTER,
+    ITAU,
+    XP,
+    PICPAY
+}

--- a/src/main/java/com/example/bills/service/BillService.java
+++ b/src/main/java/com/example/bills/service/BillService.java
@@ -1,6 +1,7 @@
 package com.example.bills.service;
 
 import com.example.bills.model.Bill;
+import com.example.bills.model.BillType;
 import com.example.bills.repository.BillRepository;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -27,6 +28,9 @@ public class BillService {
 
     @Transactional
     public Bill save(Bill bill) {
+        if (bill.getType() == BillType.CREDIT_CARD && bill.getCreditCardName() == null) {
+            throw new IllegalArgumentException("Credit card bills must include card name");
+        }
         return billRepository.save(bill);
     }
 

--- a/src/test/java/com/example/bills/BillServiceTests.java
+++ b/src/test/java/com/example/bills/BillServiceTests.java
@@ -1,7 +1,7 @@
 package com.example.bills;
 
 import com.example.bills.model.Bill;
-import com.example.bills.repository.BillRepository;
+import com.example.bills.model.BillType;
 import com.example.bills.service.BillService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -12,15 +12,13 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.SimpleMailMessage;
 
 import java.time.LocalDate;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 class BillServiceTests {
 
     @Autowired
     private BillService billService;
-
-    @Autowired
-    private BillRepository billRepository;
 
     @MockBean
     private JavaMailSender mailSender;
@@ -31,10 +29,22 @@ class BillServiceTests {
         bill.setName("Internet");
         bill.setDueDate(LocalDate.now());
         bill.setEmail("test@example.com");
-        billRepository.save(bill);
+        bill.setType(BillType.INTERNET);
+        billService.save(bill);
 
         billService.sendDueBillsReminders();
 
         Mockito.verify(mailSender).send(Mockito.any(SimpleMailMessage.class));
+    }
+
+    @Test
+    void creditCardRequiresCardName() {
+        Bill bill = new Bill();
+        bill.setName("Credit Card");
+        bill.setDueDate(LocalDate.now());
+        bill.setEmail("test@example.com");
+        bill.setType(BillType.CREDIT_CARD);
+
+        assertThrows(IllegalArgumentException.class, () -> billService.save(bill));
     }
 }


### PR DESCRIPTION
## Summary
- add BillType and CreditCardName enums
- support bill type and optional credit card name in Bill entity
- validate credit card bills require a card name
- adjust tests for new bill type field

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_689775be29bc832ebb71043591104755