### PR TITLE
feat: add monthly bill reminders

### DIFF
--- a/src/main/java/com/example/bills/service/BillService.java
+++ b/src/main/java/com/example/bills/service/BillService.java
@@ -12,7 +12,9 @@ import org.springframework.scheduling.annotation.Scheduled;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 
 @Slf4j
@@ -37,21 +39,66 @@ public class BillService {
 
     @Scheduled(fixedRate = 1 * 60 * 1000)
     public void sendDueBillsReminders() {
-        List<Bill> dueBills = billRepository.findByDueDate(LocalDate.now());
-        for (Bill bill : dueBills) {
-            SimpleMailMessage message = new SimpleMailMessage();
-            message.setTo(bill.getEmail());
-            message.setSubject("Bill due: " + bill.getName());
-            message.setText("Your bill " + bill.getName() + " is due today.");
-            try {
-                mailSender.send(message);
-            } catch (MailException e) {
-                log.error("Failed to send reminder for {}: {}", bill.getName(), e.getMessage());
+        sendDueBillsReminders(LocalDate.now());
+    }
+
+    void sendDueBillsReminders(LocalDate today) {
+        List<Bill> bills = billRepository.findAll();
+        boolean reminderSent = false;
+
+        for (Bill bill : bills) {
+            LocalDate dueDate = calculateNextDueDate(bill, today);
+            if (today.equals(dueDate.minusDays(1))) {
+                sendEmail(bill, "Bill due tomorrow: " + bill.getName(),
+                        "Your bill " + bill.getName() + " is due on " + dueDate + ".");
+                reminderSent = true;
+            }
+
+            LocalDate adjustedDueDate = adjustForWeekend(dueDate);
+            if (today.equals(adjustedDueDate)) {
+                sendEmail(bill, "Bill due: " + bill.getName(),
+                        "Your bill " + bill.getName() + " is due today.");
+                reminderSent = true;
             }
         }
-        
-        if (dueBills.isEmpty()) {
-        	log.warn("There are no bills to be reminded");
+
+        if (!reminderSent) {
+            log.warn("There are no bills to be reminded");
+        }
+    }
+
+    private LocalDate calculateNextDueDate(Bill bill, LocalDate referenceDate) {
+        int day = bill.getDueDate().getDayOfMonth();
+
+        LocalDate dueDateThisMonth = LocalDate.of(referenceDate.getYear(), referenceDate.getMonth(),
+                Math.min(day, referenceDate.lengthOfMonth()));
+        LocalDate adjustedThisMonth = adjustForWeekend(dueDateThisMonth);
+
+        if (!referenceDate.isAfter(adjustedThisMonth)) {
+            return dueDateThisMonth;
+        }
+
+        LocalDate nextMonth = referenceDate.plusMonths(1);
+        return LocalDate.of(nextMonth.getYear(), nextMonth.getMonth(),
+                Math.min(day, nextMonth.lengthOfMonth()));
+    }
+
+    private LocalDate adjustForWeekend(LocalDate date) {
+        if (date.getDayOfWeek() == DayOfWeek.SATURDAY || date.getDayOfWeek() == DayOfWeek.SUNDAY) {
+            return date.with(TemporalAdjusters.next(DayOfWeek.MONDAY));
+        }
+        return date;
+    }
+
+    private void sendEmail(Bill bill, String subject, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(bill.getEmail());
+        message.setSubject(subject);
+        message.setText(text);
+        try {
+            mailSender.send(message);
+        } catch (MailException e) {
+            log.error("Failed to send reminder for {}: {}", bill.getName(), e.getMessage());
         }
     }
 }

--- a/src/test/java/com/example/bills/service/BillServiceTest.java
+++ b/src/test/java/com/example/bills/service/BillServiceTest.java
@@ -1,0 +1,68 @@
+package com.example.bills.service;
+
+import com.example.bills.model.Bill;
+import com.example.bills.model.BillType;
+import com.example.bills.repository.BillRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BillServiceTest {
+
+    @Mock
+    private BillRepository billRepository;
+    @Mock
+    private JavaMailSender mailSender;
+    @Captor
+    private ArgumentCaptor<SimpleMailMessage> mailCaptor;
+
+    private BillService billService;
+
+    @BeforeEach
+    void setUp() {
+        billService = new BillService(billRepository, mailSender);
+    }
+
+    @Test
+    void shouldSendReminderOneDayBeforeDueDate() {
+        Bill bill = new Bill();
+        bill.setName("Internet");
+        bill.setEmail("test@example.com");
+        bill.setType(BillType.INTERNET);
+        bill.setDueDate(LocalDate.of(2024, 5, 10));
+        when(billRepository.findAll()).thenReturn(List.of(bill));
+
+        billService.sendDueBillsReminders(LocalDate.of(2024, 5, 9));
+
+        verify(mailSender).send(mailCaptor.capture());
+        assertThat(mailCaptor.getValue().getSubject()).contains("Bill due tomorrow");
+    }
+
+    @Test
+    void shouldSendReminderOnNextBusinessDayWhenDueDateIsWeekend() {
+        Bill bill = new Bill();
+        bill.setName("Electricity");
+        bill.setEmail("test@example.com");
+        bill.setType(BillType.ELECTRICITY);
+        bill.setDueDate(LocalDate.of(2024, 5, 25)); // Saturday
+        when(billRepository.findAll()).thenReturn(List.of(bill));
+
+        billService.sendDueBillsReminders(LocalDate.of(2024, 5, 27)); // Monday
+
+        verify(mailSender).send(mailCaptor.capture());
+        assertThat(mailCaptor.getValue().getSubject()).contains("Bill due:");
+    }
+}


### PR DESCRIPTION
## Summary
- send reminders one day before and on the (adjusted) due date
- adjust weekend due dates to the following Monday
- add service tests for reminder scheduling

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to offline repository)*

------
https://chatgpt.com/codex/tasks/task_e_6897b368cad8832e96fdd2031f812d84