### PR TITLE
Add endpoint to mark bills as paid

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ Configure an SMTP server via the `spring.mail.*` properties. For local testing y
 ```
 mvn test
 ```
+
+## API
+
+- `POST /bills` – register a new bill.
+- `GET /bills` – list all bills.
+- `GET /bills/reminder` – manually trigger due bill reminders.
+- `POST /bills/{id}/paid` – mark a bill as paid so no reminder is sent.

--- a/src/main/java/com/example/bills/controller/BillController.java
+++ b/src/main/java/com/example/bills/controller/BillController.java
@@ -32,6 +32,12 @@ public class BillController {
     
     @GetMapping("/reminder")
     public void forceReminder() {
-    	billService.sendDueBillsReminders();
+        billService.sendDueBillsReminders();
+    }
+
+    @PostMapping("/{id}/paid")
+    public Bill markAsPaid(@PathVariable Long id) {
+        log.info("Marking bill {} as paid", id);
+        return billService.markAsPaid(id);
     }
 }

--- a/src/main/java/com/example/bills/model/Bill.java
+++ b/src/main/java/com/example/bills/model/Bill.java
@@ -26,4 +26,5 @@ public class Bill {
     private BillType type;
     @Enumerated(EnumType.STRING)
     private CreditCardName creditCardName;
+    private boolean paid;
 }

--- a/src/main/java/com/example/bills/repository/BillRepository.java
+++ b/src/main/java/com/example/bills/repository/BillRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 
 public interface BillRepository extends JpaRepository<Bill, Long> {
     List<Bill> findByDueDate(LocalDate dueDate);
+    List<Bill> findByPaidFalse();
 }

--- a/src/main/java/com/example/bills/service/BillService.java
+++ b/src/main/java/com/example/bills/service/BillService.java
@@ -37,13 +37,21 @@ public class BillService {
         return billRepository.findAll();
     }
 
+    @Transactional
+    public Bill markAsPaid(Long id) {
+        Bill bill = billRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Bill not found"));
+        bill.setPaid(true);
+        return billRepository.save(bill);
+    }
+
     @Scheduled(fixedRate = 1 * 60 * 1000)
     public void sendDueBillsReminders() {
         sendDueBillsReminders(LocalDate.now());
     }
 
     void sendDueBillsReminders(LocalDate today) {
-        List<Bill> bills = billRepository.findAll();
+        List<Bill> bills = billRepository.findByPaidFalse();
         boolean reminderSent = false;
 
         for (Bill bill : bills) {

--- a/src/test/java/com/example/bills/service/BillServiceTest.java
+++ b/src/test/java/com/example/bills/service/BillServiceTest.java
@@ -43,7 +43,7 @@ class BillServiceTest {
         bill.setEmail("test@example.com");
         bill.setType(BillType.INTERNET);
         bill.setDueDate(LocalDate.of(2024, 5, 10));
-        when(billRepository.findAll()).thenReturn(List.of(bill));
+        when(billRepository.findByPaidFalse()).thenReturn(List.of(bill));
 
         billService.sendDueBillsReminders(LocalDate.of(2024, 5, 9));
 
@@ -58,11 +58,20 @@ class BillServiceTest {
         bill.setEmail("test@example.com");
         bill.setType(BillType.ELECTRICITY);
         bill.setDueDate(LocalDate.of(2024, 5, 25)); // Saturday
-        when(billRepository.findAll()).thenReturn(List.of(bill));
+        when(billRepository.findByPaidFalse()).thenReturn(List.of(bill));
 
         billService.sendDueBillsReminders(LocalDate.of(2024, 5, 27)); // Monday
 
         verify(mailSender).send(mailCaptor.capture());
         assertThat(mailCaptor.getValue().getSubject()).contains("Bill due:");
+    }
+
+    @Test
+    void shouldNotSendReminderForPaidBills() {
+        when(billRepository.findByPaidFalse()).thenReturn(List.of());
+
+        billService.sendDueBillsReminders(LocalDate.of(2024, 5, 10));
+
+        verify(mailSender, never()).send(any(SimpleMailMessage.class));
     }
 }


### PR DESCRIPTION
## Summary
- Track paid bills with a new `paid` flag
- Allow marking a bill as paid via `/bills/{id}/paid`
- Skip reminders for bills already paid and document API
- Fetch only unpaid bills when sending reminders to avoid iterating over paid bills

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6897b824de30832ea1413c2d920f01ed