### PR TITLE
feat: send overdue bill reminder

### DIFF
--- a/src/test/java/com/example/bills/service/BillServiceTest.java
+++ b/src/test/java/com/example/bills/service/BillServiceTest.java
@@ -67,6 +67,21 @@ class BillServiceTest {
     }
 
     @Test
+    void shouldSendReminderWhenBillIsOverdue() {
+        Bill bill = new Bill();
+        bill.setName("Water");
+        bill.setEmail("test@example.com");
+        bill.setType(BillType.WATER);
+        bill.setDueDate(LocalDate.of(2024, 5, 10));
+        when(billRepository.findByPaidFalse()).thenReturn(List.of(bill));
+
+        billService.sendDueBillsReminders(LocalDate.of(2024, 5, 11));
+
+        verify(mailSender).send(mailCaptor.capture());
+        assertThat(mailCaptor.getValue().getSubject()).contains("Bill overdue");
+    }
+
+    @Test
     void shouldNotSendReminderForPaidBills() {
         when(billRepository.findByPaidFalse()).thenReturn(List.of());
 


### PR DESCRIPTION
## Summary
- notify users when unpaid bills are past due
- test overdue reminder behavior
- refactor reminder loop into focused helper methods for overdue, due tomorrow, and due today logic

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6897be1256f4832e928efa41f04d1367