### PR TITLE
Allow cross-origin requests for bills API

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,5 +12,11 @@ spring:
     # dummy mail configuration
     host: localhost
     port: 2525
+  web:
+    cors:
+      allowed-origins: "*"
+      allowed-methods: "*"
+      allowed-headers: "*"
 
-server.port: 8015
+server:
+  port: 8015


### PR DESCRIPTION
## Summary
- configure CORS globally in application.yml
- remove controller-level CrossOrigin annotation

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898ac3dcda8832eb2b9f8d1fd227f3e