### PR TITLE
Fix overdue detection for next-month bills

### DIFF
--- a/src/main/java/com/example/bills/service/BillService.java
+++ b/src/main/java/com/example/bills/service/BillService.java
@@ -73,7 +73,7 @@ public class BillService {
         for (Bill bill : bills) {
         	LocalDate dueDate = calculateNextDueDate(bill, today);
         	
-            if (handleOverdue(bill, today)) {
+            if (handleOverdue(bill, today, dueDate)) {
             	//
             }
             else if (handleDueTomorrow(bill, today, dueDate)) {
@@ -87,15 +87,12 @@ public class BillService {
         }
     }
 
-    private boolean handleOverdue(Bill bill, LocalDate today) {
-        int day = bill.getDueDate().getDayOfMonth();
-        LocalDate dueDateThisMonth = LocalDate.of(today.getYear(), today.getMonth(),
-                Math.min(day, today.lengthOfMonth()));
-        LocalDate adjustedDueDateThisMonth = adjustForWeekend(dueDateThisMonth);
-        if (today.isAfter(adjustedDueDateThisMonth)) {
+    private boolean handleOverdue(Bill bill, LocalDate today, LocalDate dueDate) {
+        LocalDate adjustedDueDate = adjustForWeekend(dueDate);
+        if (today.isAfter(adjustedDueDate)) {
             String subject = String.format("Bill overdue: %s", bill.getName());
             String body = String.format("Your bill %s was due on %s. Please pay(if not) and mark it as paid.",
-                    bill.getName(), adjustedDueDateThisMonth);
+                    bill.getName(), adjustedDueDate);
             sendEmail(bill, subject, body);
             log.info(subject);
             return true;

--- a/src/test/java/com/example/bills/service/BillServiceTest.java
+++ b/src/test/java/com/example/bills/service/BillServiceTest.java
@@ -83,6 +83,20 @@ class BillServiceTest {
     }
 
     @Test
+    void shouldNotConsiderNextMonthBillAsOverdue() {
+        Bill bill = new Bill();
+        bill.setName("Internet");
+        bill.setEmail("test@example.com");
+        bill.setType(BillType.INTERNET);
+        bill.setDueDate(LocalDate.of(2024, 6, 10));
+        when(billRepository.findByPaidFalse()).thenReturn(List.of(bill));
+
+        billService.sendDueBillsReminders(LocalDate.of(2024, 5, 11));
+
+        verify(mailSender, never()).send(any(SimpleMailMessage.class));
+    }
+
+    @Test
     void shouldNotSendReminderForPaidBills() {
         when(billRepository.findByPaidFalse()).thenReturn(List.of());
 


### PR DESCRIPTION
## Summary
- ensure overdue check uses next computed due date to avoid flagging future bills as overdue
- add regression test for next-month bill not being considered overdue

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898b7fd0b20832e9cd7467423e98a76