### PR TITLE
Add deletion route for bills

### DIFF
--- a/src/main/java/com/example/bills/controller/BillController.java
+++ b/src/main/java/com/example/bills/controller/BillController.java
@@ -48,6 +48,13 @@ public class BillController {
         billService.sendDueBillsReminders();
     }
 
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
+        log.info("Deleting bill {}", id);
+        billService.delete(id);
+    }
+
     @PostMapping("/{id}/paid")
     public Bill markAsPaid(@PathVariable Long id) {
         log.info("Marking bill {} as paid", id);

--- a/src/main/java/com/example/bills/service/BillService.java
+++ b/src/main/java/com/example/bills/service/BillService.java
@@ -44,6 +44,14 @@ public class BillService {
     }
 
     @Transactional
+    public void delete(Long id) {
+        if (!billRepository.existsById(id)) {
+            throw new IllegalArgumentException("Bill not found");
+        }
+        billRepository.deleteById(id);
+    }
+
+    @Transactional
     public Bill markAsPaid(Long id) {
         Bill bill = billRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Bill not found"));

--- a/src/test/java/com/example/bills/BillServiceTests.java
+++ b/src/test/java/com/example/bills/BillServiceTests.java
@@ -82,6 +82,20 @@ class BillServiceTests {
     }
 
     @Test
+    void deletesBill() {
+        Bill bill = new Bill();
+        bill.setName("Internet");
+        bill.setDueDate(LocalDate.now());
+        bill.setEmail("test@example.com");
+        bill.setType(BillType.INTERNET);
+        billService.save(bill);
+
+        billService.delete(bill.getId());
+
+        assertTrue(billService.findAll().isEmpty());
+    }
+
+    @Test
     void findsBillsByMonthAndStatus() {
         Bill paidBill = new Bill();
         paidBill.setName("Electricity");


### PR DESCRIPTION
## Summary
- add DELETE /bills/{id} endpoint for removing bills
- implement service deletion logic with existence check
- cover deletion behavior with integration test

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898bac29c20832eb457df4b60c530d9