### PR TITLE
Handle future-month due dates without recalculating

### DIFF
--- a/src/main/java/com/example/bills/service/BillService.java
+++ b/src/main/java/com/example/bills/service/BillService.java
@@ -124,7 +124,16 @@ public class BillService {
     }
 
     private LocalDate calculateNextDueDate(Bill bill, LocalDate referenceDate) {
-        int day = bill.getDueDate().getDayOfMonth();
+        LocalDate billDueDate = bill.getDueDate();
+
+        // If the bill's due date is already in a future month, keep it unchanged
+        if (billDueDate.getYear() > referenceDate.getYear() ||
+                (billDueDate.getYear() == referenceDate.getYear() &&
+                        billDueDate.getMonthValue() > referenceDate.getMonthValue())) {
+            return billDueDate;
+        }
+
+        int day = billDueDate.getDayOfMonth();
 
         LocalDate dueDateThisMonth = LocalDate.of(referenceDate.getYear(), referenceDate.getMonth(),
                 Math.min(day, referenceDate.lengthOfMonth()));

--- a/src/test/java/com/example/bills/service/BillServiceTest.java
+++ b/src/test/java/com/example/bills/service/BillServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 
+import java.lang.reflect.Method;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -94,6 +95,19 @@ class BillServiceTest {
         billService.sendDueBillsReminders(LocalDate.of(2024, 5, 11));
 
         verify(mailSender, never()).send(any(SimpleMailMessage.class));
+    }
+
+    @Test
+    void shouldKeepDueDateWhenBillIsInFutureMonth() throws Exception {
+        Bill bill = new Bill();
+        bill.setDueDate(LocalDate.of(2024, 8, 10));
+
+        Method method = BillService.class.getDeclaredMethod("calculateNextDueDate", Bill.class, LocalDate.class);
+        method.setAccessible(true);
+
+        LocalDate result = (LocalDate) method.invoke(billService, bill, LocalDate.of(2024, 5, 11));
+
+        assertThat(result).isEqualTo(bill.getDueDate());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Keep bill's due date unchanged when it is already set for a future month
- Test that calculating next due date respects future-month bills

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.example:bills-reminder: The following artifacts could not be resolved... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898ba7da5f4832eb681c6fe86e377cf