### PR TITLE
Use Mailjet for email notifications

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,9 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-mail</artifactId>
+            <groupId>com.mailjet</groupId>
+            <artifactId>mailjet-client</artifactId>
+            <version>5.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/example/bills/service/BillService.java
+++ b/src/main/java/com/example/bills/service/BillService.java
@@ -3,14 +3,12 @@ package com.example.bills.service;
 import com.example.bills.model.Bill;
 import com.example.bills.model.BillType;
 import com.example.bills.repository.BillRepository;
-import org.springframework.mail.SimpleMailMessage;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.MailException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.scheduling.annotation.Scheduled;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -23,7 +21,7 @@ import java.util.List;
 public class BillService {
 
     private final BillRepository billRepository;
-    private final JavaMailSender mailSender;
+    private final EmailService emailService;
 
     @Transactional
     public Bill save(Bill bill) {
@@ -164,14 +162,6 @@ public class BillService {
     }
 
     private void sendEmail(Bill bill, String subject, String text) {
-        SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(bill.getEmail());
-        message.setSubject(subject);
-        message.setText(text);
-        try {
-            mailSender.send(message);
-        } catch (MailException e) {
-            log.error("Failed to send reminder for {}: {}", bill.getName(), e.getMessage());
-        }
+        emailService.sendEmail(bill.getEmail(), subject, text);
     }
 }

--- a/src/main/java/com/example/bills/service/EmailService.java
+++ b/src/main/java/com/example/bills/service/EmailService.java
@@ -1,0 +1,5 @@
+package com.example.bills.service;
+
+public interface EmailService {
+    void sendEmail(String to, String subject, String body);
+}

--- a/src/main/java/com/example/bills/service/MailjetEmailService.java
+++ b/src/main/java/com/example/bills/service/MailjetEmailService.java
@@ -1,0 +1,44 @@
+package com.example.bills.service;
+
+import com.mailjet.client.ClientOptions;
+import com.mailjet.client.MailjetClient;
+import com.mailjet.client.MailjetRequest;
+import com.mailjet.client.errors.MailjetException;
+import com.mailjet.client.errors.MailjetSocketTimeoutException;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class MailjetEmailService implements EmailService {
+
+    private final MailjetClient client;
+    private final String fromEmail = "noreply@billsreminder.com";
+
+    public MailjetEmailService(@Value("${mailjet.api-key}") String apiKey,
+                               @Value("${mailjet.api-secret}") String apiSecret) {
+        this.client = new MailjetClient(apiKey, apiSecret, new ClientOptions("v3.1"));
+    }
+
+    @Override
+    public void sendEmail(String to, String subject, String body) {
+        MailjetRequest request = new MailjetRequest(com.mailjet.client.resource.Emailv31.resource)
+                .property(com.mailjet.client.resource.Emailv31.MESSAGES, new JSONArray()
+                        .put(new JSONObject()
+                                .put(com.mailjet.client.resource.Emailv31.Message.FROM, new JSONObject()
+                                        .put("Email", fromEmail))
+                                .put(com.mailjet.client.resource.Emailv31.Message.TO, new JSONArray()
+                                        .put(new JSONObject()
+                                                .put("Email", to)))
+                                .put(com.mailjet.client.resource.Emailv31.Message.SUBJECT, subject)
+                                .put(com.mailjet.client.resource.Emailv31.Message.TEXTPART, body)));
+        try {
+            client.post(request);
+        } catch (MailjetException | MailjetSocketTimeoutException e) {
+            log.error("Failed to send email via Mailjet: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,15 +6,15 @@ spring:
     hibernate:
       ddl-auto: update
     database-platform: org.hibernate.community.dialect.SQLiteDialect
-  mail:
-    # dummy mail configuration
-    host: localhost
-    port: 2525
   web:
     cors:
       allowed-origins: "*"
       allowed-methods: "*"
       allowed-headers: "*"
+
+mailjet:
+  api-key: YOUR_API_KEY
+  api-secret: YOUR_API_SECRET
 
 server:
   port: 8015

--- a/src/test/java/com/example/bills/BillServiceTests.java
+++ b/src/test/java/com/example/bills/BillServiceTests.java
@@ -3,6 +3,7 @@ package com.example.bills;
 import com.example.bills.model.Bill;
 import com.example.bills.model.BillType;
 import com.example.bills.service.BillService;
+import com.example.bills.service.EmailService;
 import com.example.bills.repository.BillRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,8 +11,6 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.SimpleMailMessage;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -27,7 +26,7 @@ class BillServiceTests {
     private BillRepository billRepository;
 
     @MockBean
-    private JavaMailSender mailSender;
+    private EmailService emailService;
 
     @BeforeEach
     void clean() {
@@ -45,7 +44,7 @@ class BillServiceTests {
 
         billService.sendDueBillsReminders();
 
-        Mockito.verify(mailSender).send(Mockito.any(SimpleMailMessage.class));
+        Mockito.verify(emailService).sendEmail(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
     }
 
     @Test

--- a/src/test/java/com/example/bills/service/BillServiceTest.java
+++ b/src/test/java/com/example/bills/service/BillServiceTest.java
@@ -10,8 +10,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mail.SimpleMailMessage;
-import org.springframework.mail.javamail.JavaMailSender;
 
 import java.lang.reflect.Method;
 import java.time.LocalDate;
@@ -27,15 +25,15 @@ class BillServiceTest {
     @Mock
     private BillRepository billRepository;
     @Mock
-    private JavaMailSender mailSender;
+    private EmailService emailService;
     @Captor
-    private ArgumentCaptor<SimpleMailMessage> mailCaptor;
+    private ArgumentCaptor<String> subjectCaptor;
 
     private BillService billService;
 
     @BeforeEach
     void setUp() {
-        billService = new BillService(billRepository, mailSender);
+        billService = new BillService(billRepository, emailService);
     }
 
     @Test
@@ -49,8 +47,8 @@ class BillServiceTest {
 
         billService.sendDueBillsReminders(LocalDate.of(2024, 5, 9));
 
-        verify(mailSender).send(mailCaptor.capture());
-        assertThat(mailCaptor.getValue().getSubject()).contains("Bill due tomorrow");
+        verify(emailService).sendEmail(eq(bill.getEmail()), subjectCaptor.capture(), anyString());
+        assertThat(subjectCaptor.getValue()).contains("Bill due tomorrow");
     }
 
     @Test
@@ -64,8 +62,8 @@ class BillServiceTest {
 
         billService.sendDueBillsReminders(LocalDate.of(2024, 5, 27)); // Monday
 
-        verify(mailSender).send(mailCaptor.capture());
-        assertThat(mailCaptor.getValue().getSubject()).contains("Bill due:");
+        verify(emailService).sendEmail(eq(bill.getEmail()), subjectCaptor.capture(), anyString());
+        assertThat(subjectCaptor.getValue()).contains("Bill due:");
     }
 
     @Test
@@ -79,8 +77,8 @@ class BillServiceTest {
 
         billService.sendDueBillsReminders(LocalDate.of(2024, 5, 11));
 
-        verify(mailSender).send(mailCaptor.capture());
-        assertThat(mailCaptor.getValue().getSubject()).contains("Bill overdue");
+        verify(emailService).sendEmail(eq(bill.getEmail()), subjectCaptor.capture(), anyString());
+        assertThat(subjectCaptor.getValue()).contains("Bill overdue");
     }
 
     @Test
@@ -94,7 +92,7 @@ class BillServiceTest {
 
         billService.sendDueBillsReminders(LocalDate.of(2024, 5, 11));
 
-        verify(mailSender, never()).send(any(SimpleMailMessage.class));
+        verify(emailService, never()).sendEmail(anyString(), anyString(), anyString());
     }
 
     @Test
@@ -116,7 +114,7 @@ class BillServiceTest {
 
         billService.sendDueBillsReminders(LocalDate.of(2024, 5, 10));
 
-        verify(mailSender, never()).send(any(SimpleMailMessage.class));
+        verify(emailService, never()).sendEmail(anyString(), anyString(), anyString());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- switch email service to Mailjet using new `MailjetEmailService`
- add Mailjet dependency and configuration for API keys
- adjust bill tests to use the new email service abstraction

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898dadff270832e85e8e41011838838