### PR TITLE
Add Flyway migration for OTHER enum values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,10 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-flyway</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.mailjet</groupId>
             <artifactId>mailjet-client</artifactId>
             <version>5.2.1</version>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,8 +4,10 @@ spring:
     driverClassName: org.sqlite.JDBC
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     database-platform: org.hibernate.community.dialect.SQLiteDialect
+  flyway:
+    enabled: true
   web:
     cors:
       allowed-origins: "*"

--- a/src/main/resources/db/migration/V2__allow_other.sql
+++ b/src/main/resources/db/migration/V2__allow_other.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS bill;
+
+CREATE TABLE bill (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    due_date DATE,
+    email TEXT,
+    type TEXT CHECK (type IN ('INTERNET','WATER','CELLPHONE_PLAN','MEI','ELECTRICITY','GAS','CREDIT_CARD','OTHER')),
+    credit_card_name TEXT CHECK (credit_card_name IN ('INTER','ITAU','XP','PICPAY','OTHER')),
+    paid INTEGER NOT NULL DEFAULT 0
+);


### PR DESCRIPTION
## Summary
- add Flyway dependency and enable migrations
- recreate bill table with CHECK constraints that include 'OTHER'

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e79b31e8832ebbcdea8133ab539c